### PR TITLE
Revert Polaris client changes from main

### DIFF
--- a/src/datalake_mcp_server_client/api/delta_lake/get_database_structure.py
+++ b/src/datalake_mcp_server_client/api/delta_lake/get_database_structure.py
@@ -70,12 +70,12 @@ def sync_detailed(
     client: AuthenticatedClient,
     body: DatabaseStructureRequest,
 ) -> Response[DatabaseStructureResponse | ErrorResponse]:
-    """Get Iceberg database structure
+    """Get database structure
 
-     Gets the complete structure of all Iceberg namespaces, optionally including table schemas.
+     Gets the complete structure of all databases, optionally including table schemas.
 
     Args:
-        body (DatabaseStructureRequest): Request model for getting Iceberg database structure.
+        body (DatabaseStructureRequest): Request model for getting database structure.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -101,12 +101,12 @@ def sync(
     client: AuthenticatedClient,
     body: DatabaseStructureRequest,
 ) -> DatabaseStructureResponse | ErrorResponse | None:
-    """Get Iceberg database structure
+    """Get database structure
 
-     Gets the complete structure of all Iceberg namespaces, optionally including table schemas.
+     Gets the complete structure of all databases, optionally including table schemas.
 
     Args:
-        body (DatabaseStructureRequest): Request model for getting Iceberg database structure.
+        body (DatabaseStructureRequest): Request model for getting database structure.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,12 +127,12 @@ async def asyncio_detailed(
     client: AuthenticatedClient,
     body: DatabaseStructureRequest,
 ) -> Response[DatabaseStructureResponse | ErrorResponse]:
-    """Get Iceberg database structure
+    """Get database structure
 
-     Gets the complete structure of all Iceberg namespaces, optionally including table schemas.
+     Gets the complete structure of all databases, optionally including table schemas.
 
     Args:
-        body (DatabaseStructureRequest): Request model for getting Iceberg database structure.
+        body (DatabaseStructureRequest): Request model for getting database structure.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -156,12 +156,12 @@ async def asyncio(
     client: AuthenticatedClient,
     body: DatabaseStructureRequest,
 ) -> DatabaseStructureResponse | ErrorResponse | None:
-    """Get Iceberg database structure
+    """Get database structure
 
-     Gets the complete structure of all Iceberg namespaces, optionally including table schemas.
+     Gets the complete structure of all databases, optionally including table schemas.
 
     Args:
-        body (DatabaseStructureRequest): Request model for getting Iceberg database structure.
+        body (DatabaseStructureRequest): Request model for getting database structure.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/datalake_mcp_server_client/api/delta_lake/get_table_schema.py
+++ b/src/datalake_mcp_server_client/api/delta_lake/get_table_schema.py
@@ -72,10 +72,10 @@ def sync_detailed(
 ) -> Response[ErrorResponse | TableSchemaResponse]:
     """Get table schema
 
-     Gets the schema (column names) of a specific table in an Iceberg namespace.
+     Gets the schema (column names) of a specific table in a database.
 
     Args:
-        body (TableSchemaRequest): Request model for getting table schema from an Iceberg catalog.
+        body (TableSchemaRequest): Request model for getting table schema.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,10 +103,10 @@ def sync(
 ) -> ErrorResponse | TableSchemaResponse | None:
     """Get table schema
 
-     Gets the schema (column names) of a specific table in an Iceberg namespace.
+     Gets the schema (column names) of a specific table in a database.
 
     Args:
-        body (TableSchemaRequest): Request model for getting table schema from an Iceberg catalog.
+        body (TableSchemaRequest): Request model for getting table schema.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -129,10 +129,10 @@ async def asyncio_detailed(
 ) -> Response[ErrorResponse | TableSchemaResponse]:
     """Get table schema
 
-     Gets the schema (column names) of a specific table in an Iceberg namespace.
+     Gets the schema (column names) of a specific table in a database.
 
     Args:
-        body (TableSchemaRequest): Request model for getting table schema from an Iceberg catalog.
+        body (TableSchemaRequest): Request model for getting table schema.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -158,10 +158,10 @@ async def asyncio(
 ) -> ErrorResponse | TableSchemaResponse | None:
     """Get table schema
 
-     Gets the schema (column names) of a specific table in an Iceberg namespace.
+     Gets the schema (column names) of a specific table in a database.
 
     Args:
-        body (TableSchemaRequest): Request model for getting table schema from an Iceberg catalog.
+        body (TableSchemaRequest): Request model for getting table schema.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/datalake_mcp_server_client/api/delta_lake/list_database_tables.py
+++ b/src/datalake_mcp_server_client/api/delta_lake/list_database_tables.py
@@ -70,12 +70,12 @@ def sync_detailed(
     client: AuthenticatedClient,
     body: TableListRequest,
 ) -> Response[ErrorResponse | TableListResponse]:
-    """List tables in an Iceberg namespace
+    """List tables in a database
 
-     Lists all tables in a specific Iceberg namespace (catalog.namespace format).
+     Lists all tables in a specific database, optionally using PostgreSQL for faster retrieval.
 
     Args:
-        body (TableListRequest): Request model for listing tables in an Iceberg namespace.
+        body (TableListRequest): Request model for listing tables in a database.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -101,12 +101,12 @@ def sync(
     client: AuthenticatedClient,
     body: TableListRequest,
 ) -> ErrorResponse | TableListResponse | None:
-    """List tables in an Iceberg namespace
+    """List tables in a database
 
-     Lists all tables in a specific Iceberg namespace (catalog.namespace format).
+     Lists all tables in a specific database, optionally using PostgreSQL for faster retrieval.
 
     Args:
-        body (TableListRequest): Request model for listing tables in an Iceberg namespace.
+        body (TableListRequest): Request model for listing tables in a database.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,12 +127,12 @@ async def asyncio_detailed(
     client: AuthenticatedClient,
     body: TableListRequest,
 ) -> Response[ErrorResponse | TableListResponse]:
-    """List tables in an Iceberg namespace
+    """List tables in a database
 
-     Lists all tables in a specific Iceberg namespace (catalog.namespace format).
+     Lists all tables in a specific database, optionally using PostgreSQL for faster retrieval.
 
     Args:
-        body (TableListRequest): Request model for listing tables in an Iceberg namespace.
+        body (TableListRequest): Request model for listing tables in a database.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -156,12 +156,12 @@ async def asyncio(
     client: AuthenticatedClient,
     body: TableListRequest,
 ) -> ErrorResponse | TableListResponse | None:
-    """List tables in an Iceberg namespace
+    """List tables in a database
 
-     Lists all tables in a specific Iceberg namespace (catalog.namespace format).
+     Lists all tables in a specific database, optionally using PostgreSQL for faster retrieval.
 
     Args:
-        body (TableListRequest): Request model for listing tables in an Iceberg namespace.
+        body (TableListRequest): Request model for listing tables in a database.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/datalake_mcp_server_client/api/delta_lake/list_databases.py
+++ b/src/datalake_mcp_server_client/api/delta_lake/list_databases.py
@@ -70,13 +70,13 @@ def sync_detailed(
     client: AuthenticatedClient,
     body: DatabaseListRequest,
 ) -> Response[DatabaseListResponse | ErrorResponse]:
-    """List all Iceberg namespaces
+    """List all databases in the Hive metastore
 
-     Lists all accessible Iceberg namespaces across all catalogs. Returns namespaces in catalog.namespace
-    format.
+     Lists all databases available in the Hive metastore, optionally using PostgreSQL for faster
+    retrieval and filtered by user namespace.
 
     Args:
-        body (DatabaseListRequest): Request model for listing databases from Iceberg catalogs.
+        body (DatabaseListRequest): Request model for listing databases.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -102,13 +102,13 @@ def sync(
     client: AuthenticatedClient,
     body: DatabaseListRequest,
 ) -> DatabaseListResponse | ErrorResponse | None:
-    """List all Iceberg namespaces
+    """List all databases in the Hive metastore
 
-     Lists all accessible Iceberg namespaces across all catalogs. Returns namespaces in catalog.namespace
-    format.
+     Lists all databases available in the Hive metastore, optionally using PostgreSQL for faster
+    retrieval and filtered by user namespace.
 
     Args:
-        body (DatabaseListRequest): Request model for listing databases from Iceberg catalogs.
+        body (DatabaseListRequest): Request model for listing databases.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -129,13 +129,13 @@ async def asyncio_detailed(
     client: AuthenticatedClient,
     body: DatabaseListRequest,
 ) -> Response[DatabaseListResponse | ErrorResponse]:
-    """List all Iceberg namespaces
+    """List all databases in the Hive metastore
 
-     Lists all accessible Iceberg namespaces across all catalogs. Returns namespaces in catalog.namespace
-    format.
+     Lists all databases available in the Hive metastore, optionally using PostgreSQL for faster
+    retrieval and filtered by user namespace.
 
     Args:
-        body (DatabaseListRequest): Request model for listing databases from Iceberg catalogs.
+        body (DatabaseListRequest): Request model for listing databases.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,13 +159,13 @@ async def asyncio(
     client: AuthenticatedClient,
     body: DatabaseListRequest,
 ) -> DatabaseListResponse | ErrorResponse | None:
-    """List all Iceberg namespaces
+    """List all databases in the Hive metastore
 
-     Lists all accessible Iceberg namespaces across all catalogs. Returns namespaces in catalog.namespace
-    format.
+     Lists all databases available in the Hive metastore, optionally using PostgreSQL for faster
+    retrieval and filtered by user namespace.
 
     Args:
-        body (DatabaseListRequest): Request model for listing databases from Iceberg catalogs.
+        body (DatabaseListRequest): Request model for listing databases.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/datalake_mcp_server_client/models/database_list_request.py
+++ b/src/datalake_mcp_server_client/models/database_list_request.py
@@ -6,26 +6,50 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 T = TypeVar("T", bound="DatabaseListRequest")
 
 
 @_attrs_define
 class DatabaseListRequest:
-    """Request model for listing databases from Iceberg catalogs."""
+    """Request model for listing databases.
 
+    Attributes:
+        use_hms (bool | Unset): Whether to use Hive Metastore client for faster metadata retrieval Default: True.
+        filter_by_namespace (bool | Unset): Whether to filter databases by user/tenant namespace prefixes Default: True.
+    """
+
+    use_hms: bool | Unset = True
+    filter_by_namespace: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        use_hms = self.use_hms
+
+        filter_by_namespace = self.filter_by_namespace
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if use_hms is not UNSET:
+            field_dict["use_hms"] = use_hms
+        if filter_by_namespace is not UNSET:
+            field_dict["filter_by_namespace"] = filter_by_namespace
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        database_list_request = cls()
+        use_hms = d.pop("use_hms", UNSET)
+
+        filter_by_namespace = d.pop("filter_by_namespace", UNSET)
+
+        database_list_request = cls(
+            use_hms=use_hms,
+            filter_by_namespace=filter_by_namespace,
+        )
 
         database_list_request.additional_properties = d
         return database_list_request

--- a/src/datalake_mcp_server_client/models/database_structure_request.py
+++ b/src/datalake_mcp_server_client/models/database_structure_request.py
@@ -13,23 +13,29 @@ T = TypeVar("T", bound="DatabaseStructureRequest")
 
 @_attrs_define
 class DatabaseStructureRequest:
-    """Request model for getting Iceberg database structure.
+    """Request model for getting database structure.
 
     Attributes:
         with_schema (bool | Unset): Whether to include table schemas in the response Default: False.
+        use_hms (bool | Unset): Whether to use Hive Metastore client for faster metadata retrieval Default: True.
     """
 
     with_schema: bool | Unset = False
+    use_hms: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         with_schema = self.with_schema
+
+        use_hms = self.use_hms
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if with_schema is not UNSET:
             field_dict["with_schema"] = with_schema
+        if use_hms is not UNSET:
+            field_dict["use_hms"] = use_hms
 
         return field_dict
 
@@ -38,8 +44,11 @@ class DatabaseStructureRequest:
         d = dict(src_dict)
         with_schema = d.pop("with_schema", UNSET)
 
+        use_hms = d.pop("use_hms", UNSET)
+
         database_structure_request = cls(
             with_schema=with_schema,
+            use_hms=use_hms,
         )
 
         database_structure_request.additional_properties = d

--- a/src/datalake_mcp_server_client/models/table_list_request.py
+++ b/src/datalake_mcp_server_client/models/table_list_request.py
@@ -6,22 +6,28 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 T = TypeVar("T", bound="TableListRequest")
 
 
 @_attrs_define
 class TableListRequest:
-    """Request model for listing tables in an Iceberg namespace.
+    """Request model for listing tables in a database.
 
     Attributes:
-        database (str): Namespace in catalog.namespace format (e.g., my.demo)
+        database (str): Name of the database to list tables from
+        use_hms (bool | Unset): Whether to use Hive Metastore client for faster metadata retrieval Default: True.
     """
 
     database: str
+    use_hms: bool | Unset = True
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         database = self.database
+
+        use_hms = self.use_hms
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -30,6 +36,8 @@ class TableListRequest:
                 "database": database,
             }
         )
+        if use_hms is not UNSET:
+            field_dict["use_hms"] = use_hms
 
         return field_dict
 
@@ -38,8 +46,11 @@ class TableListRequest:
         d = dict(src_dict)
         database = d.pop("database")
 
+        use_hms = d.pop("use_hms", UNSET)
+
         table_list_request = cls(
             database=database,
+            use_hms=use_hms,
         )
 
         table_list_request.additional_properties = d

--- a/src/datalake_mcp_server_client/models/table_schema_request.py
+++ b/src/datalake_mcp_server_client/models/table_schema_request.py
@@ -11,10 +11,10 @@ T = TypeVar("T", bound="TableSchemaRequest")
 
 @_attrs_define
 class TableSchemaRequest:
-    """Request model for getting table schema from an Iceberg catalog.
+    """Request model for getting table schema.
 
     Attributes:
-        database (str): Namespace in catalog.namespace format (e.g., my.demo)
+        database (str): Name of the database containing the table
         table (str): Name of the table to get schema for
     """
 


### PR DESCRIPTION
Reverts PR #7 which regenerated the client with Iceberg-related model changes (removed use_hms, filter_by_namespace fields). Polaris work is preserved on the feature/polaris branch.